### PR TITLE
Fix Edge Cases With `as_tree`

### DIFF
--- a/src/html_parser.gleam
+++ b/src/html_parser.gleam
@@ -160,20 +160,25 @@ pub fn as_tree(in: String) -> Element {
 }
 
 fn do_as_tree(in: String, current: Element) -> #(Element, String) {
-  let #(next, remain) = get_first_element(in)
-  let assert StartElement(cur_name, cur_attrs, cur_children) = current
-  case next {
-    EndElement(name) if name == cur_name -> #(
-      StartElement(cur_name, cur_attrs, cur_children |> list.reverse),
-      remain,
-    )
-    EndElement(_) -> do_as_tree(remain, current)
-    _ -> {
-      let #(child_tree, remain_after_child) = do_as_tree(remain, next)
-      do_as_tree(
-        remain_after_child,
-        StartElement(cur_name, cur_attrs, [child_tree, ..cur_children]),
-      )
+  case current {
+    Content(_) -> #(current, in)
+    StartElement(cur_name, cur_attrs, cur_children) -> {
+      let #(next, remain) = get_first_element(in)
+      case next {
+        EndElement(name) if name == cur_name -> #(
+          StartElement(cur_name, cur_attrs, cur_children |> list.reverse),
+          remain,
+        )
+        EndElement(_) -> do_as_tree(remain, current)
+        _ -> {
+          let #(child_tree, remain_after_child) = do_as_tree(remain, next)
+          do_as_tree(
+            remain_after_child,
+            StartElement(cur_name, cur_attrs, [child_tree, ..cur_children]),
+          )
+        }
+      }
     }
+    _ -> #(current, in)
   }
 }

--- a/test/html_parser_test.gleam
+++ b/test/html_parser_test.gleam
@@ -9,11 +9,15 @@ pub fn main() {
   gleeunit.main()
 }
 
-fn find_span_tree(in: html_parser.Element) -> Option(html_parser.Element) {
+fn find_div_tree(in: html_parser.Element) -> Option(html_parser.Element) {
   case in {
-    html_parser.StartElement("span", _, _) -> Some(in)
+    html_parser.StartElement(
+      "div",
+      [html_parser.Attribute("class", "definition")],
+      _,
+    ) -> Some(in)
     html_parser.StartElement(_, _, children) -> {
-      let subs = list.map(children, find_span_tree)
+      let subs = list.map(children, find_div_tree)
       case list.find(subs, option.is_some) {
         Ok(res) -> {
           res
@@ -55,11 +59,17 @@ pub fn parse_aloha_list_test() {
 }
 
 pub fn parse_aloha_tree_test() {
-  let assert Ok(input) = read(from: "test/simple.html")
-  input
-  |> html_parser.as_tree
-  |> find_span_tree
-  |> should.equal(Some(html_parser.StartElement("span", [], [])))
+  let assert Ok(input) = read(from: "test/aloha.html")
+
+  let assert Some(div) =
+    input
+    |> html_parser.as_tree
+    |> find_div_tree
+
+  let assert html_parser.StartElement(name, attrs, _) = div
+
+  should.equal(name, "div")
+  should.equal(attrs, [html_parser.Attribute("class", "definition")])
 }
 
 pub fn get_first_element_test() {


### PR DESCRIPTION
Hey!

I'm using this package for an internal tool, but I ran into some problems. I managed to fix them however, so I thought I'll contribute them to your package.

`as_list` was working fine but with `as_tree` I had some errors:
- text content did not match any nodes (f.e. "<div>some text</div>")
- self closing tags resulted in a timeout (f.e. "<meta chartset="..." />")

As mentioned they are fixed with this PR and I also added some tests to cover them.

Cheers!